### PR TITLE
Phantom.js issue

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,7 +5,8 @@
     "-Promise",
     "$",
     "Mousetrap",
-    "Switchery"
+    "Switchery",
+    "require"
   ],
   "browser": true,
   "boss": true,

--- a/testem.js
+++ b/testem.js
@@ -3,8 +3,15 @@ module.exports = {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
+  "launchers": {
+    "AltPhantom": {
+      "exe": "phantomjs",
+      "args": ["tests/phantom-runner.js"],
+      "protocol": "browser"
+    }
+  },
   "launch_in_ci": [
-    "PhantomJS"
+    "AltPhantom"
   ],
   "launch_in_dev": [
     "PhantomJS",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -24,7 +24,8 @@
     "currentRouteName",
     "$",
     "Mousetrap",
-    "Switchery"
+    "Switchery",
+    "require"
   ],
   "node": false,
   "browser": false,

--- a/tests/phantom-runner.js
+++ b/tests/phantom-runner.js
@@ -1,0 +1,16 @@
+var system = require('system');
+var page = require('webpage').create();
+var url = system.args[1];
+
+page.viewportSize = {
+  width: 1024,
+  height: 768
+};
+
+page.onResourceRequested = function(requestData, networkRequest) {
+  if (requestData.url.match('fonts.googleapis.com')) {
+    networkRequest.abort();
+  }
+};
+
+page.open(url);


### PR DESCRIPTION
As per this [thread](https://github.com/ember-cli/ember-cli/issues/3894), there seems to be an issue related to Phantom.js that occurs during on the when testing the app and trying to load third-party resources such as Web Fonts and CSS. This PR adds a rule to prevent Phantom.js from checking these external resources, solving the Travis [testing issues](https://travis-ci.org/iorrah/you-rockstar/builds/284143923).